### PR TITLE
Only reinstall Installomator when version doesn't match pinned

### DIFF
--- a/intunemacs.sh
+++ b/intunemacs.sh
@@ -87,87 +87,96 @@ destFile="/usr/local/Installomator/Installomator.sh"
 currentInstalledVersion="$(${destFile} version 2>/dev/null || true)"
 printlog "${destFile} version: $currentInstalledVersion"
 
-# Check if we need to remove existing installation
-if [[ -e "${destFile}" ]]; then
-    printlog "Existing Installomator installation found. Removing it before installing version ${appNewVersion}..."
-    rm -f "${destFile}" || true
+# Install only if Installomator is missing or not the pinned version.
+# (Previously this removed and reinstalled on every run, regardless of version.)
+if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" ]]; then
+    printlog "$name not found or version does not match pinned ${appNewVersion}."
+    printlog "${destFile}"
 
-    # Also remove the directory if it exists
-    if [[ -d "/usr/local/Installomator" ]]; then
-        rm -rf "/usr/local/Installomator" || true
-        printlog "Removed existing Installomator directory"
+    # Remove any existing installation before installing the pinned version
+    if [[ -e "${destFile}" ]]; then
+        printlog "Existing Installomator installation found. Removing it before installing version ${appNewVersion}..."
+        rm -f "${destFile}" || true
+
+        # Also remove the directory if it exists
+        if [[ -d "/usr/local/Installomator" ]]; then
+            rm -rf "/usr/local/Installomator" || true
+            printlog "Removed existing Installomator directory"
+        fi
     fi
-fi
 
-printlog "Installing specific version ${appNewVersion} ..."
+    printlog "Installing specific version ${appNewVersion} ..."
 
-# Create temporary working directory
-tmpDir="$(mktemp -d || true)"
-printlog "Created working directory '$tmpDir'"
+    # Create temporary working directory
+    tmpDir="$(mktemp -d || true)"
+    printlog "Created working directory '$tmpDir'"
 
-# Download the installer package
-printlog "Downloading $name package version $appNewVersion from: $downloadURL"
-installationCount=0
-exitCode=9
-while [[ $installationCount -lt 3 && $exitCode -gt 0 ]]; do
-    curlDownload=$(curl -Ls "$downloadURL" -o "$tmpDir/$name.pkg" || true)
-    curlDownloadStatus=$(echo $?)
-    if [[ $curlDownloadStatus -ne 0 ]]; then
-        printlog "error downloading $downloadURL, with status $curlDownloadStatus"
-        printlog "${curlDownload}"
-        exitCode=1
-    else
-        printlog "Download $name success."
-        # Verify the download
-        teamID=$(spctl -a -vv -t install "$tmpDir/$name.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()' || true)
-        printlog "Team ID for downloaded package: $teamID"
-        # Install the package if Team ID validates
-        if [ "$expectedTeamID" = "$teamID" ] || [ "$expectedTeamID" = "" ]; then
-            printlog "$name package verified. Installing package '$tmpDir/$name.pkg'."
-            pkgInstall=$(installer -verbose -dumplog -pkg "$tmpDir/$name.pkg" -target "/" 2>&1)
-            pkgInstallStatus=$(echo $?)
-            if [[ $pkgInstallStatus -ne 0 ]]; then
-                printlog "ERROR. $name package installation failed."
-                printlog "${pkgInstall}"
-                exitCode=2
+    # Download the installer package
+    printlog "Downloading $name package version $appNewVersion from: $downloadURL"
+    installationCount=0
+    exitCode=9
+    while [[ $installationCount -lt 3 && $exitCode -gt 0 ]]; do
+        curlDownload=$(curl -Ls "$downloadURL" -o "$tmpDir/$name.pkg" || true)
+        curlDownloadStatus=$(echo $?)
+        if [[ $curlDownloadStatus -ne 0 ]]; then
+            printlog "error downloading $downloadURL, with status $curlDownloadStatus"
+            printlog "${curlDownload}"
+            exitCode=1
+        else
+            printlog "Download $name success."
+            # Verify the download
+            teamID=$(spctl -a -vv -t install "$tmpDir/$name.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()' || true)
+            printlog "Team ID for downloaded package: $teamID"
+            # Install the package if Team ID validates
+            if [ "$expectedTeamID" = "$teamID" ] || [ "$expectedTeamID" = "" ]; then
+                printlog "$name package verified. Installing package '$tmpDir/$name.pkg'."
+                pkgInstall=$(installer -verbose -dumplog -pkg "$tmpDir/$name.pkg" -target "/" 2>&1)
+                pkgInstallStatus=$(echo $?)
+                if [[ $pkgInstallStatus -ne 0 ]]; then
+                    printlog "ERROR. $name package installation failed."
+                    printlog "${pkgInstall}"
+                    exitCode=2
+                else
+                    printlog "Installing $name package success."
+                    exitCode=0
+                fi
             else
-                printlog "Installing $name package success."
-                exitCode=0
+                printlog "ERROR. Package verification failed for $name before package installation could start. Download link may be invalid."
+                exitCode=3
+            fi
+        fi
+        ((installationCount++))
+        printlog "$installationCount time(s), exitCode $exitCode"
+        if [[ $installationCount -lt 3 ]]; then
+            if [[ $exitCode -gt 0 ]]; then
+                printlog "Sleep a bit before trying download and install again. $installationCount time(s)."
+                printlog "Remove $(rm -fv "$tmpDir/$name.pkg" || true)"
+                sleep 2
             fi
         else
-            printlog "ERROR. Package verification failed for $name before package installation could start. Download link may be invalid."
-            exitCode=3
+            printlog "Download and install of $name success."
         fi
-    fi
-    ((installationCount++))
-    printlog "$installationCount time(s), exitCode $exitCode"
-    if [[ $installationCount -lt 3 ]]; then
-        if [[ $exitCode -gt 0 ]]; then
-            printlog "Sleep a bit before trying download and install again. $installationCount time(s)."
-            printlog "Remove $(rm -fv "$tmpDir/$name.pkg" || true)"
-            sleep 2
-        fi
+    done
+
+    # Remove the temporary working directory
+    printlog "Deleting working directory '$tmpDir' and its contents."
+    printlog "Remove $(rm -Rfv "${tmpDir}" || true)"
+
+    # Handle installation errors
+    if [[ $exitCode != 0 ]]; then
+        printlog "ERROR. Installation of $name failed. Aborting."
+        caffexit $exitCode
     else
-        printlog "Download and install of $name success."
+        # Verify the installed version
+        installedVersion="$(${destFile} version 2>/dev/null || true)"
+        if [[ "$installedVersion" == "$appNewVersion" ]]; then
+            printlog "$name specific version $appNewVersion installed successfully!"
+        else
+            printlog "WARNING: Installed version ($installedVersion) does not match requested version ($appNewVersion)."
+        fi
     fi
-done
-
-# Remove the temporary working directory
-printlog "Deleting working directory '$tmpDir' and its contents."
-printlog "Remove $(rm -Rfv "${tmpDir}" || true)"
-
-# Handle installation errors
-if [[ $exitCode != 0 ]]; then
-    printlog "ERROR. Installation of $name failed. Aborting."
-    caffexit $exitCode
 else
-    # Verify the installed version
-    installedVersion="$(${destFile} version 2>/dev/null || true)"
-    if [[ "$installedVersion" == "$appNewVersion" ]]; then
-        printlog "$name specific version $appNewVersion installed successfully!"
-    else
-        printlog "WARNING: Installed version ($installedVersion) does not match requested version ($appNewVersion)."
-    fi
+    printlog "$name version $appNewVersion already found. Perfect!"
 fi
 
 # Check and install Swift Dialog


### PR DESCRIPTION
## Problem

`intunemacs.sh` removes and re-downloads Installomator on **every run**, even when the pinned version (`specificVersion`, currently 10.8) is already installed. The guard around the removal is an existence check only:

```sh
if [[ -e "${destFile}" ]]; then
    rm -f "${destFile}" ...   # fires whenever the file exists, regardless of version
fi
```

`currentInstalledVersion` is read just above but never compared, so there's no version gating.

## Cause

The original code was version-gated:

```sh
if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" ]]; then
    # install
else
    # already correct, skip
fi
```

That gate was dropped in the "rollback to 10.7" change (commit `ba95e7bf`, 2026-04-02) when the script switched from tracking GitHub's latest release to pinning a specific version. The removal/install was split into two unconditional steps and the `!= appNewVersion` check was lost in the rewrite.

## Fix

Restore the version gate by wrapping the removal/download/install/verify block in:

```sh
if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" ]]; then
    ...
else
    printlog "$name version $appNewVersion already found. Perfect!"
fi
```

### Behaviour after the change
- Pinned version already installed → skip entirely (no teardown, no re-download).
- Wrong version (older or newer) → remove + reinstall the pinned version (downgrade still works, since the check is `!=` not `>=`).
- Not installed → install the pinned version.

The inner removal/download/install logic is unchanged (only re-indented). Verified with `bash -n`.