### PR TITLE
Complete caffexit fixes missed when #4/#5 merged early

### DIFF
--- a/intunemacs.sh
+++ b/intunemacs.sh
@@ -165,7 +165,9 @@ if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" ]]; t
     # Handle installation errors
     if [[ $exitCode != 0 ]]; then
         printlog "ERROR. Installation of $name failed. Aborting."
-        caffexit $exitCode
+        # Plain exit: caffexit() is not defined yet here and caffeinate has not
+        # been started, so calling it produces "caffexit: command not found".
+        exit $exitCode
     else
         # Verify the installed version
         installedVersion="$(${destFile} version 2>/dev/null || true)"
@@ -513,7 +515,9 @@ fi
 caffeinatepid=$!
 caffexit () {
     kill "$caffeinatepid"
-    exit 0
+    # Propagate the real exit status so failed installs are reported as failed
+    # to the MDM (previously this always exited 0, masking every failure).
+    exit "${1:-0}"
 }
 
 # Mark: Installation begins

--- a/intunemacsupdateonly.sh
+++ b/intunemacsupdateonly.sh
@@ -527,7 +527,9 @@ fi
 caffeinatepid=$!
 caffexit () {
     kill "$caffeinatepid"
-    exit 0
+    # Propagate the real exit status so failed installs are reported as failed
+    # to the MDM (previously this always exited 0, masking every failure).
+    exit "${1:-0}"
 }
 
 # Mark: Installation begins


### PR DESCRIPTION
Follow-up to #4 and #5, which were merged before all their commits landed, so two fixes never reached `main`.

### Still on main before this PR
- `intunemacs.sh`: bootstrap failure handler still calls `caffexit $exitCode` while `caffexit()` isn't defined yet (the `/bin/sh: line 162: caffexit: command not found` the customer hit), and `caffexit()` still hardcodes `exit 0`.
- `intunemacsupdateonly.sh`: `caffexit()` still hardcodes `exit 0`.

### This PR
- `intunemacs.sh`: bootstrap failure path → plain `exit $exitCode`; `caffexit()` → `exit "${1:-0}"`.
- `intunemacsupdateonly.sh`: `caffexit()` → `exit "${1:-0}"`.

### Behaviour
- **Successful install** → `exitStatus` is 0 → `exit 0` → MDM reports **success** (unchanged).
- **Failed install** → real non-zero code now propagates → MDM reports **failed** (previously masked as success).

Verified with `bash -n`.